### PR TITLE
Fix NA handling in categorical data validation

### DIFF
--- a/R/mHMM.R
+++ b/R/mHMM.R
@@ -576,9 +576,9 @@ mHMM <- function(s_data, data_distr = 'categorical', gen, xx = NULL, start_val, 
     if(length(q_emiss) != n_dep){
       stop("The lenght of q_emiss specifying the number of output categories for each of the number of dependent variables should equal the number of dependent variables specified in n_dep")
     }
-    if(sum(apply(as.matrix(s_data[,2:(n_dep + 1)], ncol = n_dep), 2, function(x) length(unique(x))) != q_emiss) > 0 |
-       min(s_data[,2:(n_dep + 1)]) < 1 |
-       sum(apply(as.matrix(s_data[,2:(n_dep + 1)], ncol = n_dep), 2, max) > q_emiss) > 0){
+    if(sum(apply(as.matrix(s_data[,2:(n_dep + 1)], ncol = n_dep), 2, function(x) length(unique(x[!is.na(x)]))) != q_emiss) > 0 |
+       min(s_data[,2:(n_dep + 1)], na.rm = TRUE) < 1 |
+       sum(apply(as.matrix(s_data[,2:(n_dep + 1)], ncol = n_dep), 2, function(x) max(x, na.rm = TRUE)) > q_emiss) > 0){
       stop("For categorical input variables, the values should be integers ranging from 1 to number of observed categories specified for each of the dependent variables in q_emiss")
     }
   } else {


### PR DESCRIPTION
## Summary
- Fixed a bug where the mHMM function would fail when categorical input data contained NA values
- Added proper NA handling to the validation logic for categorical data

## Problem
The package was unable to handle missing data (NAs) in categorical input variables, throwing the error:
```
Error in mHMM(s_data = nonverbal_na, gen = list(m = m, n_dep = n_dep,  : 
  For categorical input variables, the values should be integers ranging from 1 to number of observed categories specified for each of the dependent variables in q_emiss
```

This was inconsistent with how the package handles continuous data, which already supports NAs.

## Solution
Modified the validation check in `R/mHMM.R` (lines 579-581) to:
1. Filter out NAs when checking unique values per category using `x[!is.na(x)]`
2. Use `na.rm = TRUE` for min/max calculations
3. Apply `na.rm = TRUE` within the max function for each dependent variable

## Test plan
✅ Tested with the nonverbal dataset:
- Runs successfully with complete data
- Now runs successfully with 1% missing data (360 NAs)
- Model results are comparable between complete and NA-containing datasets

Test code available in the issue/discussion if needed.

🤖 Generated with [Claude Code](https://claude.ai/code)